### PR TITLE
3.2.0 - Create cron job for resource consumer

### DIFF
--- a/yaml/resource-consumer/resource-consumer.yaml
+++ b/yaml/resource-consumer/resource-consumer.yaml
@@ -34,7 +34,7 @@ kind: CronJob
 metadata:
   name: curl-resource-consumer
 spec:
-  schedule: "*/2 * * * *"
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
@@ -48,13 +48,13 @@ spec:
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "millicores=300&durationSec=700"
+              - "millicores=300&durationSec=120"
               - http://resource-consumer.consumer:8080/ConsumeCPU
           - name: curl-mem
             image: curlimages/curl
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "megabytes=256&durationSec=700"
+              - "megabytes=256&durationSec=120"
               - http://resource-consumer.consumer:8080/ConsumeMem
           restartPolicy: OnFailure


### PR DESCRIPTION
The change in this PR adds a yaml file to create the necessary resources to be able to trigger the resource consumer via a cronjob. Three resources have been created:

1. The resource-consumer pod, which actually runs resource-consumer inside a container.
2. A Service resource to enable DNS lookup for the resource-consumer pod.
3. A CronJob resource which will curl the HTTP endpoints for resource-consumer every 5 minutes, with a duration of 120 seconds. Why 120 seconds? Just to ensure that Prometheus actually registers the resource usage of resource-consumer, since the metrics are retrieved every 60 seconds. Any number > 60 seconds seems to do the trick. Note that these parameters might need to be adjusted in the future to retrieve useful values from the CronJob.

Example of how the corresponding metrics look in Prometheus:

CPU
The seconds that the CPU is being used increases during two metric scrapes (2 minutes), then the CPU usage is 0 (constant value in the graph) for 3 minutes, then the cron job is activated again, and the loop repeats.
![prometheus-resource-consumer-cpu](https://user-images.githubusercontent.com/4168364/145244669-75eea4cf-a678-4a6f-b273-ec50fedb42a5.png)

RAM
RAM usage increases from 0 to approximately 256Mib during one metric scrape, stays there during another metric scrape, and goes down during the third metric scrape, resulting in 2 minutes of memory usage. Then the memory usage is 0 for 3 minutes, after which the cronjob is executed again, and the cycle repeats.
![prometheus-resource-consumer-mem](https://user-images.githubusercontent.com/4168364/145244700-b883ad00-9fe4-4491-a2f9-8327f68546d0.png)