### PR TITLE
Resource consumer deployment

### DIFF
--- a/yaml/resource-consumer/resource-consumer-constant.yaml
+++ b/yaml/resource-consumer/resource-consumer-constant.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: resource-consumer-constant
+spec:
+  selector:
+    app: resource-consumer-constant
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-consumer-constant
+  labels:
+    name: resource-consumer-constant
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: resource-consumer-constant
+  template:
+    metadata:
+      labels:
+        app: resource-consumer-constant
+    spec:
+      containers:
+        - name: resource-consumer-constant
+          image: gcr.io/k8s-staging-e2e-test-images/resource-consumer:1.9
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 300m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: curl-resource-consumer-constant
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Replace
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: curl-cpu
+            image: curlimages/curl
+            imagePullPolicy: IfNotPresent
+            args:
+              - -d
+              - "millicores=300&durationSec=43200"
+              - http://resource-consumer-constant:8080/ConsumeCPU
+          - name: curl-mem
+            image: curlimages/curl
+            imagePullPolicy: IfNotPresent
+            args:
+              - -d
+              - "megabytes=256&durationSec=43200"
+              - http://resource-consumer-constant:8080/ConsumeMem
+          restartPolicy: OnFailure

--- a/yaml/resource-consumer/resource-consumer-constant.yaml
+++ b/yaml/resource-consumer/resource-consumer-constant.yaml
@@ -33,10 +33,10 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              cpu: 300m
-              memory: 256Mi
+              cpu: 150m
+              memory: 128Mi
             limits:
-              memory: 512Mi
+              memory: 256Mi
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -57,13 +57,13 @@ spec:
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "millicores=300&durationSec=43200"
+              - "millicores=150&durationSec=43200"
               - http://resource-consumer-constant:8080/ConsumeCPU
           - name: curl-mem
             image: curlimages/curl
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "megabytes=256&durationSec=43200"
+              - "megabytes=128&durationSec=43200"
               - http://resource-consumer-constant:8080/ConsumeMem
           restartPolicy: OnFailure

--- a/yaml/resource-consumer/resource-consumer-periodic.yaml
+++ b/yaml/resource-consumer/resource-consumer-periodic.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: resource-consumer
+  name: resource-consumer-periodic
 spec:
   selector:
-    app: resource-consumer
+    app: resource-consumer-periodic
   ports:
     - protocol: TCP
       port: 8080
@@ -13,21 +13,21 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: resource-consumer
+  name: resource-consumer-periodic
   labels:
-    name: resource-consumer
+    name: resource-consumer-periodic
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: resource-consumer
+      app: resource-consumer-periodic
   template:
     metadata:
       labels:
-        app: resource-consumer
+        app: resource-consumer-periodic
     spec:
       containers:
-        - name: resource-consumer
+        - name: resource-consumer-periodic
           image: gcr.io/k8s-staging-e2e-test-images/resource-consumer:1.9
           ports:
             - containerPort: 8080
@@ -41,7 +41,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: curl-resource-consumer
+  name: curl-resource-consumer-periodic
 spec:
   schedule: "*/10 * * * *"
   concurrencyPolicy: Replace
@@ -58,12 +58,12 @@ spec:
             args:
               - -d
               - "millicores=300&durationSec=300"
-              - http://resource-consumer:8080/ConsumeCPU
+              - http://resource-consumer-periodic:8080/ConsumeCPU
           - name: curl-mem
             image: curlimages/curl
             imagePullPolicy: IfNotPresent
             args:
               - -d
               - "megabytes=256&durationSec=300"
-              - http://resource-consumer:8080/ConsumeMem
+              - http://resource-consumer-periodic:8080/ConsumeMem
           restartPolicy: OnFailure

--- a/yaml/resource-consumer/resource-consumer-periodic.yaml
+++ b/yaml/resource-consumer/resource-consumer-periodic.yaml
@@ -33,10 +33,10 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              cpu: 600m
-              memory: 512Mi
+              cpu: 300m
+              memory: 256Mi
             limits:
-              memory: 1024Mi
+              memory: 512Mi
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -57,13 +57,13 @@ spec:
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "millicores=600&durationSec=300"
+              - "millicores=300&durationSec=300"
               - http://resource-consumer-periodic:8080/ConsumeCPU
           - name: curl-mem
             image: curlimages/curl
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "megabytes=512&durationSec=300"
+              - "megabytes=256&durationSec=300"
               - http://resource-consumer-periodic:8080/ConsumeMem
           restartPolicy: OnFailure

--- a/yaml/resource-consumer/resource-consumer-periodic.yaml
+++ b/yaml/resource-consumer/resource-consumer-periodic.yaml
@@ -33,10 +33,10 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              cpu: 300m
-              memory: 256Mi
-            limits:
+              cpu: 600m
               memory: 512Mi
+            limits:
+              memory: 1024Mi
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -57,13 +57,13 @@ spec:
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "millicores=300&durationSec=300"
+              - "millicores=600&durationSec=300"
               - http://resource-consumer-periodic:8080/ConsumeCPU
           - name: curl-mem
             image: curlimages/curl
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "megabytes=256&durationSec=300"
+              - "megabytes=512&durationSec=300"
               - http://resource-consumer-periodic:8080/ConsumeMem
           restartPolicy: OnFailure

--- a/yaml/resource-consumer/resource-consumer.yaml
+++ b/yaml/resource-consumer/resource-consumer.yaml
@@ -1,40 +1,49 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: consumer
+  name: resource-consumer
 spec:
   selector:
-    name: resource-consumer
-  clusterIP: None
+    app: resource-consumer
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: resource-consumer
   labels:
     name: resource-consumer
 spec:
-  hostname: resource-consumer
-  subdomain: consumer
-  containers:
-  - name: resource-consumer
-    image: gcr.io/k8s-staging-e2e-test-images/resource-consumer:1.9
-    ports:
-    - containerPort: 8080
-    resources:
-      requests:
-        cpu: 300m
-        memory: 256Mi
-      limits:
-        cpu: 500m
-        memory: 512Mi
+  replicas: 1
+  selector:
+    matchLabels:
+      app: resource-consumer
+  template:
+    metadata:
+      labels:
+        app: resource-consumer
+    spec:
+      containers:
+        - name: resource-consumer
+          image: gcr.io/k8s-staging-e2e-test-images/resource-consumer:1.9
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 300m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: curl-resource-consumer
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "*/10 * * * *"
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
@@ -48,13 +57,13 @@ spec:
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "millicores=300&durationSec=120"
-              - http://resource-consumer.consumer:8080/ConsumeCPU
+              - "millicores=300&durationSec=300"
+              - http://resource-consumer:8080/ConsumeCPU
           - name: curl-mem
             image: curlimages/curl
             imagePullPolicy: IfNotPresent
             args:
               - -d
-              - "megabytes=256&durationSec=120"
-              - http://resource-consumer.consumer:8080/ConsumeMem
+              - "megabytes=256&durationSec=300"
+              - http://resource-consumer:8080/ConsumeMem
           restartPolicy: OnFailure


### PR DESCRIPTION
The changes in this pull request removes the previous resource-consumer yaml file, and creates two new ones:

One for shorter periodic resource consumtion, where the resource-consumer will consume data for 5 minutes and be idle for 5 minutes. This will consume 600 millicores of CPU when it is active, and 512MB of RAM. The name of this resource-consumer deployment is "resource-consumer-periodic".

The other one will use longer periodic consumption (In our case we will only look at one "time period"), where the resource-consumer will consume resources during 12 hours. The cron job is set to run every day, so this yaml file will basically create a resource-consumer that will consume resources for 12 hours and stay idle for 12 hours. This will consume 300 millicores of CPU when it is active, and 256MB of RAM. The name of this resource-consumer deployment is "resource-consumer-constant".